### PR TITLE
fix(docker): misunderstood CMD cause start failure on dev settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ COPY ./package.json /var/www/package.json
 
 RUN npm install
 
-CMD /wait && npm start
+CMD npm run wait-start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 node:
   build: .
-  command: /wait && npm run watch
+  command: 'npm run wait-watch'
   environment:
     APP_PORT: 17461
     APP_ENDPOINT: https://membres.openfab.be

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "scripts": {
     "start": "node src/index.js",
+    "wait-start": "/wait && npm run start",
     "watch": "nodemon --exec npm run start",
+    "wait-watch": "/wait && npm run watch",
     "test": "NODE_ENV=test LOG_LEVEL=fatal node_modules/.bin/istanbul cover node_modules/.bin/_mocha test/index.js;",
     "lint": "semistandard --verbose 'src/**/*.js' 'test/**/*.js'",
     "pretest": "npm run lint"


### PR DESCRIPTION
Adds 'waited' commands to npm scripts